### PR TITLE
Export `tab-size` as CSS custom property

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -4,9 +4,12 @@ document.addEventListener('DOMContentLoaded', () => document.body.appendChild(st
 
 // Set tab size styles
 const setTabSizeStyles = size => style.innerHTML = `
+body {
+	--tab-size: ${size};
+}
 * {
-	-moz-tab-size: ${size} !important;
-	     tab-size: ${size} !important;
+	-moz-tab-size: var(--tab-size) !important;
+	     tab-size: var(--tab-size) !important;
 }`;
 
 // Set tab size from settings on load


### PR DESCRIPTION
So that related GitHub extensions can use this value from CSS to perform their respective tasks.

Context: https://github.com/sindresorhus/refined-github/pull/1989